### PR TITLE
quickfix: add connection by SSID and channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,19 @@ bssid scan <ssid1> <ssid2> # only show result of <ssid1> and <ssid2>
 
 # connect to BSSID, will prompt for password
 bssid connect <bssid>
+
+# connect to SSID, will prompt for password
+bssid connect-ssid <ssid> <channel>
 ```
 
 ## Build
 
 ``` shell
 swift build
+```
+
+## Add command to PATH
+
+```
+ln -fs PATH_TO_LOCAL_REPOSITORY/.build/x86_64-apple-macosx/debug/bssid /usr/local/bin/
 ```

--- a/Sources/bssid/connect-ssid.swift
+++ b/Sources/bssid/connect-ssid.swift
@@ -1,0 +1,52 @@
+import Guaka
+import Foundation
+import CoreWLAN
+
+var connectSsidCommand = Command(
+        usage: "connect-ssid",
+        configuration: configuration,
+        run: execute
+)
+
+private func configuration(command: Command) {
+    command.add(flags: [
+        // Add your flags here
+    ])
+    // Other configurations
+    command.shortMessage = "connect to a WiFi network with given SSID and channel"
+    command.example = "bssid connect WifiNetwork 54"
+}
+
+private func execute(flags: Flags, args: [String]) {
+    // Execute code here
+
+    if (args.count != 2) {
+        print("require a SSID and channel")
+        return
+    }
+    let ssid = args[0]
+    let channel = (args[1] as NSString).integerValue
+
+    let wifiClient = CWWiFiClient()
+    guard let interface = wifiClient.interface(), interface.powerOn() else {
+        print("Cannot create interface or interface is not turned on")
+        return
+    }
+
+    guard let networks = try? scanNetworks(interface) else {
+        return
+    }
+
+    for network in networks {
+        if network.ssid ?? "" == ssid && network.wlanChannel?.channelNumber ?? 0 == channel {
+            print("Input WiFi password")
+            let password = String(cString: getpass(""))
+            do {
+                try interface.associate(to: network, password: password)
+            } catch {
+                print(String(format: "Failed connecting to %@, bssid %@"),
+                        network.ssid ?? "", network.bssid ?? "")
+            }
+        }
+    }
+}

--- a/Sources/bssid/setup.swift
+++ b/Sources/bssid/setup.swift
@@ -4,5 +4,6 @@ import Guaka
 func setupCommands() {
     rootCommand.add(subCommand: scanCommand)
     rootCommand.add(subCommand: connectCommand)
+    rootCommand.add(subCommand: connectSsidCommand)
     // Command adding placeholder, edit this line
 }

--- a/bssid.xcodeproj/project.pbxproj
+++ b/bssid.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06EED831244C87DF004E9C2B /* connect-ssid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EED82F244C87CF004E9C2B /* connect-ssid.swift */; };
 		OBJ_105 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* Package.swift */; };
 		OBJ_110 /* CharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* CharacterSet.swift */; };
 		OBJ_111 /* Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* Regex.swift */; };
@@ -75,6 +76,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		06EED82F244C87CF004E9C2B /* connect-ssid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "connect-ssid.swift"; sourceTree = "<group>"; };
 		"Guaka::Guaka::Product" /* Guaka.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Guaka.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		OBJ_11 /* root.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = root.swift; sourceTree = "<group>"; };
@@ -263,7 +265,7 @@
 			path = Types;
 			sourceTree = "<group>";
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -276,7 +278,6 @@
 				OBJ_65 /* bssid.entitlements */,
 				OBJ_66 /* README.md */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_51 /* StringScanner 0.3.0 */ = {
@@ -322,6 +323,7 @@
 		OBJ_8 /* bssid */ = {
 			isa = PBXGroup;
 			children = (
+				06EED82F244C87CF004E9C2B /* connect-ssid.swift */,
 				OBJ_9 /* connect.swift */,
 				OBJ_10 /* main.swift */,
 				OBJ_11 /* root.swift */,
@@ -445,7 +447,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_59 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -499,6 +501,7 @@
 				OBJ_130 /* scan.swift in Sources */,
 				OBJ_131 /* setup.swift in Sources */,
 				OBJ_132 /* utils.swift in Sources */,
+				06EED831244C87DF004E9C2B /* connect-ssid.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
For macOs 10.15.

As none of your solution work (use my developper account credential, use your branch `request-location`), this is a quickfix solution using SSID and channel. It's work great at home.

I am not a Swift developper (PHP, Java and JS at office, Python at home), I may I've done many mistakes.